### PR TITLE
Optionally create a user group whose members may manage supervisor wi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Role Variables
 ```yaml
 ---
 supervisor_group:
+supervisor_user_group: "supervisor" # a linux usergroup whose members may manage supervisor without sudo
+supervisor_group_users: # a list of linux users to add to the control group
+    - "user1"
+    - "user2"
 ```
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,5 +4,7 @@ supervisor_conf_dir: '/etc/supervisor/conf.d/'
 supervisor_log_dir: "/var/log/supervisor"
 supervisor_pid_path: "/var/run/"
 supervisor_user: "root"
+supervisor_user_group: "root"
+supervisor_group_users: []
 supervisor_init_scripts: true
 supervisor_install: true

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,7 +1,16 @@
 ---
 - pip: name=supervisor
 
-- file: path="{{supervisor_conf_dir}}" state=directory
+- group: name={{supervisor_user_group}} state=present
+
+- user: name={{item}} groups={{supervisor_user_group}} append=yes
+  with_items: '{{supervisor_group_users}}'
+
+- file: path="{{supervisor_conf_dir}}"
+    state=directory
+    owner="{{supervisor_user}}"
+    group="{{supervisor_user_group}}"
+    mode="ug=rwx,o=rx"
 
 - template: src=supervisord.conf dest="{{supervisor_config}}"
 

--- a/templates/supervisord.conf
+++ b/templates/supervisord.conf
@@ -1,6 +1,7 @@
 [unix_http_server]
 file={{supervisor_pid_path}}supervisor.sock
-chmod=0700
+chmod=0770
+chown={{supervisor_user}}:{{supervisor_user_group}}
 
 [supervisord]
 logfile={{supervisor_log_dir}}supervisord.log


### PR DESCRIPTION
…thout sudo.

In addition to the regular set up, enabling this option will create a new group, add the specified users to that group, and set the permissions on the supervisor .sock file so that group members can interact with it.
