### PR TITLE
Use custom config path in init script

### DIFF
--- a/templates/supervisor_initd
+++ b/templates/supervisor_initd
@@ -22,7 +22,7 @@
 ### END INIT INFO
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON_OPTS='-c /etc/supervisord.conf'
+DAEMON_OPTS='-c {{supervisor_config}}'
 DAEMON=/usr/local/bin/supervisord
 NAME=supervisord
 DESC=supervisor


### PR DESCRIPTION
If I set optional config path like this "/etc/superviosr/superviosrd.conf".
Init script still gets config from "/etc/supervisord.conf"